### PR TITLE
Replace URL etalab-tiles.fr by openmaptiles.data.gouv.fr

### DIFF
--- a/client/components/arreteRestriction/carte/recapitulatif.vue
+++ b/client/components/arreteRestriction/carte/recapitulatif.vue
@@ -62,7 +62,7 @@ onMounted(async () => {
   map.value = markRaw(
     new Map({
       container: mapContainer.value,
-      style: `https://etalab-tiles.fr/styles/osm-bright/style.json`,
+      style: `https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json`,
       bounds: initialState,
     }),
   );
@@ -77,7 +77,7 @@ onMounted(async () => {
     // SOURCES
     map.value?.addSource('cadastre', {
       type: 'vector',
-      url: `https://etalab-tiles.fr/data/decoupage-administratif.json`,
+      url: `https://openmaptiles.data.gouv.fr/data/decoupage-administratif.json`,
     });
 
     // LAYER

--- a/client/components/arreteRestriction/form/zonesMap.vue
+++ b/client/components/arreteRestriction/form/zonesMap.vue
@@ -55,7 +55,7 @@ onMounted(() => {
 
   map.value = new maplibregl.Map({
     container: mapContainer.value,
-    style: `https://etalab-tiles.fr/styles/osm-bright/style.json`,
+    style: `https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json`,
     bounds: initialState,
   });
 
@@ -69,7 +69,7 @@ onMounted(() => {
     // SOURCES
     map.value?.addSource('cadastre', {
       type: 'vector',
-      url: `https://etalab-tiles.fr/data/decoupage-administratif.json`,
+      url: `https://openmaptiles.data.gouv.fr/data/decoupage-administratif.json`,
     });
 
     // LAYER


### PR DESCRIPTION
We want to deprecate the domain and this is one of the only website consuming nowadays the URL
PS: URL was intended only for Covid Dashboard and has been use elsewhere whereas it should have not